### PR TITLE
Add escape characters to IoT JSON payload

### DIFF
--- a/articles/iot-hub/quickstart-send-telemetry-cli.md
+++ b/articles/iot-hub/quickstart-send-telemetry-cli.md
@@ -179,7 +179,7 @@ In this section, you update the state of the simulated device by setting propert
     *YourIotHubName*. Replace this placeholder below with the name you chose for your IoT hub.
     
     ```azurecli
-    az iot hub device-twin update -d simDevice --desired '{"conditions":{"temperature":{"warning":98, "critical":107}}}' -n {YourIoTHubName}
+    az iot hub device-twin update -d simDevice --desired '{\"conditions\":{\"temperature\":{\"warning\":98, \"critical\":107}}}' -n {YourIoTHubName}
     ```
 
 1. In the first CLI session, confirm that the simulated device outputs the property update.


### PR DESCRIPTION
the current implementation yielded an error message 

"Failed to parse json for argument 'desired' with exception:
    Expecting property name enclosed in double quotes: line 1 column 2 (char 1)"

the JSON payload must protect its internal quotation marks by “escaping” them. 

If message payload is a string that contains double quotes, then when you view the complete message object it has to escape those quotes in order to present a valid object representation of the message.

I added escapes so the JSON payload transmits as intended with the error message